### PR TITLE
[update-on-props] component now updates when new props received

### DIFF
--- a/src/SussolReactTable.jsx
+++ b/src/SussolReactTable.jsx
@@ -22,6 +22,10 @@ export class SussolReactTable extends React.Component {
     this.renderColumns = this.renderColumns.bind(this);
   }
 
+  componentWillReceiveProps(nextProps) {
+    this.setState({ tableData: nextProps.tableData });
+  }
+
   toggleSortOrder(columnKey) {
     this.setState({
       sortBy: columnKey,


### PR DESCRIPTION
This will accommodate the live update portion of the search. Currently, initial state governs the props, and they don't get updated again on state change from consumer, wrapping components.