### PR TITLE
[prop-types] removes FB warnings by adding prop-type package separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "exports-loader": "^0.6.3",
     "imports-loader": "^0.6.5",
     "material-ui": "^0.16.7",
+    "prop-types": "^15.5.10",
     "react": "^15.4.2",
     "react-addons-css-transition-group": "^15.4.2",
     "react-dom": "^15.4.2",

--- a/src/SussolReactTable.jsx
+++ b/src/SussolReactTable.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Cell, ColumnHeaderCell, EditableCell, Column, Table } from '@blueprintjs/table';
 import FlatButton from 'material-ui/FlatButton';
 import FontIcon from 'material-ui/FontIcon';
@@ -117,11 +118,11 @@ export class SussolReactTable extends React.Component {
 }
 
 SussolReactTable.propTypes = {
-  columns: React.PropTypes.array,
-  tableData: React.PropTypes.array,
-  defaultSortKey: React.PropTypes.string,
-  hideSearchBar: React.PropTypes.bool,
-  rowHeight: React.PropTypes.number,
+  columns: PropTypes.array,
+  tableData: PropTypes.array,
+  defaultSortKey: PropTypes.string,
+  hideSearchBar: PropTypes.bool,
+  rowHeight: PropTypes.number,
 };
 
 SussolReactTable.defaultProps = {


### PR DESCRIPTION
* adds `prop-types` package
* updates `React.PropTypes` -to-> `PropTypes`