### PR TITLE
API option for adding cellDataKey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ src/.DS_Store
 .DS_Store
 /lib/*
 yarn-error.log
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/*
 src/.DS_Store
 .DS_Store
 /lib/*
+yarn-error.log

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ A wrapper and simple API for using the blueprintjs data table
 # Installation
 `npm install --save sussol-react-table`
 
+# Added Options
+
+| Prop          | Type          | Description  |
+| ------------- |:-------------:| ------------ |
+| `cellDataKey` | `str`         | Pass a key (object property) from your table data set as a string. The data's key will be used to access a value &ndash; the unique key. Good for selecting the table row and loading a corresponding component, based on the selected key. e.g. `{ ... code: 123456789, ...}` |
+
 # Example
 ```
 import React from 'react';
@@ -40,6 +46,7 @@ export class App extends React.Component {
         <SussolReactTable
           columns={columns}
           tableData={data}
+          cellDataKey="code"
         />
       </div>
     );

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "test": "jest src/__tests__/SussolReactTable.spec.js"
   },
   "jest": {
-    "verbose": true,
-    "testEnvironment": "node"
+    "verbose": true
   },
   "dependencies": {
     "@blueprintjs/core": "^1.31.0",
@@ -47,6 +46,7 @@
     "eslint-plugin-jsx-a11y": "^0.6.2",
     "eslint-plugin-react": "^4.3.0",
     "jest": "18.1.0",
+    "material-ui": "^0.19.4",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-test-renderer": "^15.0.0"

--- a/src/SussolReactTable.jsx
+++ b/src/SussolReactTable.jsx
@@ -112,7 +112,7 @@ export class SussolReactTable extends React.Component {
     const value = tableData[rowIndex][columnKey] !== null ? tableData[rowIndex][columnKey] : '';
     return (
       <Cell
-        className={tableData[rowIndex][cellDataKey]}
+        className={`${cellDataKey}-${tableData[rowIndex][cellDataKey]}`}
       >
         {value}
       </Cell>
@@ -124,7 +124,7 @@ export class SussolReactTable extends React.Component {
     const value = tableData[rowIndex][columnKey] !== null ? tableData[rowIndex][columnKey] : '';
     return (
       <EditableCell
-        className={tableData[rowIndex][cellDataKey]}
+        className={`${cellDataKey}-${tableData[rowIndex][cellDataKey]}`}
         onConfirm={(newValue) => { this.editCell(rowIndex, columnKey, newValue); }}
         value={value}
       />

--- a/src/SussolReactTable.jsx
+++ b/src/SussolReactTable.jsx
@@ -28,7 +28,6 @@ export class SussolReactTable extends React.Component {
     this.state = {
       columns: props.columns || [],
       tableData: props.tableData,
-      searchTerm: '',
       sortBy: props.defaultSortKey || '',
       isAscending: true,
     };
@@ -108,46 +107,43 @@ export class SussolReactTable extends React.Component {
     );
   }
 
-  renderCell(rowIndex, columnKey) {
+  renderCell(rowIndex, columnKey, { cellDataKey }) {
     const tableData = this.state.tableData;
-    const value = tableData[rowIndex][columnKey] != null ? tableData[rowIndex][columnKey] : '';
+    const value = tableData[rowIndex][columnKey] !== null ? tableData[rowIndex][columnKey] : '';
     return (
-      <Cell>{value}</Cell>
+      <Cell
+        className={tableData[rowIndex][cellDataKey]}
+      >
+        {value}
+      </Cell>
     );
   }
 
-  renderEditableCell(rowIndex, columnKey) {
+  renderEditableCell(rowIndex, columnKey, { cellDataKey }) {
     const tableData = this.state.tableData;
-    const value = tableData[rowIndex][columnKey] != null ? tableData[rowIndex][columnKey] : '';
+    const value = tableData[rowIndex][columnKey] !== null ? tableData[rowIndex][columnKey] : '';
     return (
       <EditableCell
+        className={tableData[rowIndex][cellDataKey]}
         onConfirm={(newValue) => { this.editCell(rowIndex, columnKey, newValue); }}
         value={value}
       />
     );
   }
 
-  renderColumns() {
+  renderColumns(props) {
     const columnDefinitions = this.state.columns;
-    const columns = columnDefinitions.map((columnDef, index) => {
-      if (columnDef.editable) {
-        return (
-          <Column
-            key={index}
-            renderCell={(rowIndex) => this.renderEditableCell(rowIndex, columnDef.key)}
-            renderColumnHeader={() => this.renderColumnHeader(columnDef)}
-          />
-        );
-      }
-      return (
-        <Column
-          key={index}
-          renderCell={(rowIndex) => this.renderCell(rowIndex, columnDef.key)}
-          renderColumnHeader={() => this.renderColumnHeader(columnDef)}
-        />
-      );
-    });
-    return columns;
+
+    return columnDefinitions.map((columnDef, index) => (
+      <Column
+        key={index}
+        renderCell={(rowIndex) => columnDef.editable
+          ? this.renderEditableCell(rowIndex, columnDef.key, props)
+          : this.renderCell(rowIndex, columnDef.key, props)
+        }
+        renderColumnHeader={() => this.renderColumnHeader(columnDef)}
+      />
+    ));
   }
 
   renderSortIcon(direction) {
@@ -159,7 +155,7 @@ export class SussolReactTable extends React.Component {
   render() {
     return (
       <Table {...this.props} numRows={this.state.tableData.length}>
-        {this.renderColumns()}
+        {this.renderColumns(this.props)}
       </Table>
     );
   }

--- a/src/__tests__/SussolReactTable.spec.js
+++ b/src/__tests__/SussolReactTable.spec.js
@@ -1,9 +1,28 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import PropTypes from 'prop-types';
+import { mount, shallow } from 'enzyme';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
 
 import { SussolReactTable } from '../';
 
-test('renders Blueprint.js table', () => {
+const muiTheme = getMuiTheme();
+
+/**
+* MountWithMuiContext
+*
+* For `mount()` full DOM rendering in enzyme.
+* Provides needed context for mui to be rendered properly
+* during testing.
+*
+* @param {obj}    node - ReactElement with mui as root or child
+* @return {obj}   ReactWrapper (http://airbnb.io/enzyme/docs/api/ReactWrapper/mount.html)
+*/
+export const MountWithMuiContext = node => mount(node, {
+  context: { muiTheme },
+  childContextTypes: { muiTheme: PropTypes.object },
+});
+
+test('renders table', () => {
   const table = shallow(
     <SussolReactTable
       columns={[]}
@@ -14,7 +33,7 @@ test('renders Blueprint.js table', () => {
   expect(table.find('Table').length).toBe(1);
 });
 
-test('renders Blueprint.js table with props', () => {
+test('renders table with props', () => {
   const table = shallow(
     <SussolReactTable
       columns={[{
@@ -24,10 +43,54 @@ test('renders Blueprint.js table with props', () => {
         key: 'code',
         title: 'Code',
       }]}
-      tableData={[{ name: 'hi', title: 'Hi!'}]}
+      tableData={[{ name: 'hello', code: 123}]}
     />
   )
 
   expect(table.props().tableData.length).toBe(1);
   expect(table.props().columns.length).toBe(2);
+});
+
+test('renders cells with cellDataKey', () => {
+  const table = MountWithMuiContext(
+    <SussolReactTable
+      cellDataKey="code"
+      columns={[{
+        key: 'name',
+        title: 'Name',
+      }, {
+        key: 'code',
+        title: 'Code',
+      }]}
+      tableData={[{ name: 'hello', code: 123 }, { name: 'hey-hey', code: 456 }]}
+    />
+  )
+
+  expect(table.props().tableData.length).toBe(2);
+  expect(table.props().columns.length).toBe(2);
+  // find 4 total cells with the "code" className's attached
+  expect(table.find('.123').length).toBe(2);
+  expect(table.find('.456').length).toBe(2);
+});
+
+test('does not render cells with incorrect cellDataKey', () => {
+  const table = MountWithMuiContext(
+    <SussolReactTable
+      cellDataKey="blahblah"
+      columns={[{
+        key: 'name',
+        title: 'Name',
+      }, {
+        key: 'code',
+        title: 'Code',
+      }]}
+      tableData={[{ name: 'hello', code: 123 }, { name: 'hey-hey', code: 456 }]}
+    />
+  )
+
+  expect(table.props().tableData.length).toBe(2);
+  expect(table.props().columns.length).toBe(2);
+  // find 4 total cells with the "code" className's attached
+  expect(table.find('.123').length).toBe(0);
+  expect(table.find('.456').length).toBe(0);
 });

--- a/src/__tests__/SussolReactTable.spec.js
+++ b/src/__tests__/SussolReactTable.spec.js
@@ -69,8 +69,8 @@ test('renders cells with cellDataKey', () => {
   expect(table.props().tableData.length).toBe(2);
   expect(table.props().columns.length).toBe(2);
   // find 4 total cells with the "code" className's attached
-  expect(table.find('.123').length).toBe(2);
-  expect(table.find('.456').length).toBe(2);
+  expect(table.find('.code-123').length).toBe(2);
+  expect(table.find('.code-456').length).toBe(2);
 });
 
 test('does not render cells with incorrect cellDataKey', () => {
@@ -91,6 +91,6 @@ test('does not render cells with incorrect cellDataKey', () => {
   expect(table.props().tableData.length).toBe(2);
   expect(table.props().columns.length).toBe(2);
   // find 4 total cells with the "code" className's attached
-  expect(table.find('.123').length).toBe(0);
-  expect(table.find('.456').length).toBe(0);
+  expect(table.find('.code-123').length).toBe(0);
+  expect(table.find('.code-456').length).toBe(0);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -909,7 +909,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -982,6 +982,10 @@ boom@2.x.x:
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
   dependencies:
     hoek "2.x.x"
+
+bowser@^1.7.3:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.8.1.tgz#49785777e7302febadb1a5b71d9a646520ed310d"
 
 brace-expansion@^1.1.7:
   version "1.1.8"
@@ -1067,6 +1071,10 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+change-emitter@^0.1.2:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
 
 cheerio@^0.22.0:
   version "0.22.0"
@@ -1226,6 +1234,12 @@ cryptiles@2.x.x:
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
   dependencies:
     boom "2.x.x"
+
+css-in-js-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz#5af1dd70f4b06b331f48d22a3d86e0786c0b9435"
+  dependencies:
+    hyphenate-style-name "^1.0.2"
 
 css-select@~1.2.0:
   version "1.2.0"
@@ -1655,7 +1669,7 @@ fb-watchman@^1.8.0, fb-watchman@^1.9.0:
   dependencies:
     bser "1.0.2"
 
-fbjs@^0.8.0, fbjs@^0.8.16:
+fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.16:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -1934,6 +1948,10 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
+hoist-non-react-statics@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -1970,6 +1988,10 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+hyphenate-style-name@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
+
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
@@ -2000,6 +2022,13 @@ inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.3:
 ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+
+inline-style-prefixer@^3.0.2:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz#8551b8e5b4d573244e66a34b04f7d32076a2b534"
+  dependencies:
+    bowser "^1.7.3"
+    css-in-js-utils "^2.0.0"
 
 inquirer@^0.12.0:
   version "0.12.0"
@@ -2548,6 +2577,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+keycode@^2.1.8:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.1.9.tgz#964a23c54e4889405b4861a5c9f0480d45141dfa"
+
 kind-of@^3.0.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -2684,7 +2717,7 @@ lodash.map@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
 
-lodash.merge@^4.4.0:
+lodash.merge@^4.4.0, lodash.merge@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
@@ -2707,6 +2740,10 @@ lodash.reject@^4.4.0:
 lodash.some@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
+
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
 
 lodash.toarray@^4.4.0:
   version "4.4.0"
@@ -2745,6 +2782,22 @@ marked-terminal@^1.6.2:
 marked@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
+
+material-ui@^0.19.4:
+  version "0.19.4"
+  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-0.19.4.tgz#ca9cdca8aa8bb594dfac5db38ec9ff045a323587"
+  dependencies:
+    babel-runtime "^6.23.0"
+    inline-style-prefixer "^3.0.2"
+    keycode "^2.1.8"
+    lodash.merge "^4.6.0"
+    lodash.throttle "^4.1.1"
+    prop-types "^15.5.7"
+    react-event-listener "^0.5.1"
+    react-transition-group "^1.2.1"
+    recompose "^0.26.0"
+    simple-assign "^0.1.0"
+    warning "^3.0.0"
 
 merge@^1.1.3:
   version "1.2.0"
@@ -3118,7 +3171,7 @@ prop-types@^15.5.10:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
-prop-types@^15.5.6:
+prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -3175,6 +3228,15 @@ react-dom@^15.6.1:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
+react-event-listener@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.5.1.tgz#ba36076e47bc37c5a67ff5ccd4a9ff0f15621040"
+  dependencies:
+    babel-runtime "^6.26.0"
+    fbjs "^0.8.16"
+    prop-types "^15.6.0"
+    warning "^3.0.0"
+
 react-test-renderer@^15.0.0:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.6.2.tgz#d0333434fc2c438092696ca770da5ed48037efa8"
@@ -3182,7 +3244,7 @@ react-test-renderer@^15.0.0:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
 
-react-transition-group@^1.2.0:
+react-transition-group@^1.2.0, react-transition-group@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.2.1.tgz#e11f72b257f921b213229a774df46612346c7ca6"
   dependencies:
@@ -3245,6 +3307,15 @@ readline2@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
+
+recompose@^0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.26.0.tgz#9babff039cb72ba5bd17366d55d7232fbdfb2d30"
+  dependencies:
+    change-emitter "^0.1.2"
+    fbjs "^0.8.1"
+    hoist-non-react-statics "^2.3.1"
+    symbol-observable "^1.0.4"
 
 redeyed@~1.0.0:
   version "1.0.1"
@@ -3447,6 +3518,10 @@ signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
+simple-assign@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/simple-assign/-/simple-assign-0.1.0.tgz#17fd3066a5f3d7738f50321bb0f14ca281cc4baa"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -3575,6 +3650,10 @@ supports-color@^3.1.2:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
     has-flag "^1.0.0"
+
+symbol-observable@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
 symbol-tree@^3.2.1:
   version "3.2.2"


### PR DESCRIPTION
Fixes #8 

* Adds option for unique key across row
  * Is added to each cell as a `className` since Blueprint doesn't easily have a way to render a row `id`.
* Slight refactor of `renderColumns`
* Removed unused state `searchTerm`
* Tests added
* Adds `material-ui` to `devDependencies` for testing
* Removes `{ "testEnvironment": "node" }` from `jest` config in `package.json` so we can mount a full component (node does not have access to a browser DOM, natively)
* Updates `README.md`